### PR TITLE
Initial support for Iron Router pathFor syntax

### DIFF
--- a/client/helpers.coffee
+++ b/client/helpers.coffee
@@ -6,6 +6,10 @@ isSubReady = (sub) ->
 # return path
 pathFor = (path, view) ->
   throw new Error('no path defined') unless path
+  if path.hash?.route?
+    view = path
+    path = view.hash.route
+    delete view.hash.route
   query = if view.hash.query then FlowRouter._qs.parse(view.hash.query) else {}
   FlowRouter.path(path, view.hash, query)
 


### PR DESCRIPTION
Iron Router `pathFor` use syntaxis like this:

```
<template name="page">
    <a href="{{pathFor route='home'}}">Home</a>
</template>
```

Meanwhile in Flow Router would look like:

```
<template name="page">
    <a href="{{pathFor 'home'}}">Home</a>
</template>
```

On projects that support `Iron Router` and `Flow Router` this easy things a bit.
Now you only need switch routes without touch templates. Right now only cover `route=`

Other user case is migrate to Flow Router with minimal changes and vice versa.
