### PR TITLE
Added the `param` helper

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -6,6 +6,7 @@ Template helpers for kadira:flow-router
 - isSubReady (deprecated)
 - pathFor
 - urlFor
+- param
 - queryParam
 
 See [zimme:active-route](https://github.com/zimme/meteor-active-route) for using the following helpers
@@ -76,6 +77,14 @@ Same as pathFor, returns absolute URL.
 {{urlFor '/post/:id' id=_id}}
 ```
 
+### Usage param
+
+Returns the value for a url parameter
+
+```
+<div>ID of this post is <em>{{param 'id'}}</em></div>
+```
+
 ### Usage queryParam
 
 Returns the value for a query parameter
@@ -86,5 +95,6 @@ Returns the value for a query parameter
 
 ## Changelog:
     
+    0.4.3 - added param helper
     0.4.0 - updated to use kadira:flow-router
     0.3.0 - changed isSubReady in favor of subsReady

--- a/Readme.md
+++ b/Readme.md
@@ -27,7 +27,7 @@ meteor add arillo:flow-router-helpers
 
 Checks whether your subscriptions are ready. You can pass multiple subscription names. If you don't pass a subscription name it will check for all subscriptions to be ready.
 
-```html
+```handlebars
 {{#if subsReady 'items' 'posts'}}
   <ul>
   {{#each items}}
@@ -46,7 +46,7 @@ Checks whether your subscriptions are ready. You can pass multiple subscription 
 
 Checks whether your subscription is ready. If you don't pass a subscription name it will check for all subscriptions.
 
-```html
+```handlebars
 {{#if isSubReady 'items'}}
   <ul>
   {{#each items}}
@@ -62,7 +62,7 @@ Used to build a path to your route. First parameter can be either the path defin
 
 __Notice:__ To deparameterize the query string we are currently using the not yet official accessor for the query lib in page.js via FlowRouter._qs
 
-```html
+```handlebars
 <a href="{{pathFor '/post/:id' id=_id}}">Link to post</a>
 <a href="{{pathFor 'postRouteName' id=_id}}">Link to post</a>
 <a href="{{pathFor '/post/:id/comments/:cid' id=_id cid=comment._id}}">Link to comment in post</a>
@@ -73,7 +73,7 @@ __Notice:__ To deparameterize the query string we are currently using the not ye
 
 Same as pathFor, returns absolute URL.
 
-```
+```handlebars
 {{urlFor '/post/:id' id=_id}}
 ```
 
@@ -81,7 +81,7 @@ Same as pathFor, returns absolute URL.
 
 Returns the value for a url parameter
 
-```
+```handlebars
 <div>ID of this post is <em>{{param 'id'}}</em></div>
 ```
 
@@ -89,7 +89,7 @@ Returns the value for a url parameter
 
 Returns the value for a query parameter
 
-```
+```handlebars
 <input placeholder="Search" value="{{queryParam 'query'}}">
 ```
 

--- a/client/helpers.coffee
+++ b/client/helpers.coffee
@@ -22,6 +22,10 @@ urlFor = (path, view) ->
   Meteor.absoluteUrl(relativePath.substr(1))
 
 # get query parameter
+param = (name) ->
+  FlowRouter.getParam(name);
+
+# get query parameter
 queryParam = (key) ->
   FlowRouter.getQueryParam(key);
 
@@ -34,6 +38,7 @@ helpers =
   subsReady: subsReady
   pathFor: pathFor
   urlFor: urlFor
+  param: param
   queryParam: queryParam
   isSubReady: isSubReady
 

--- a/package.js
+++ b/package.js
@@ -2,7 +2,7 @@ Package.describe({
   git: 'https://github.com/arillo/meteor-flow-router-helpers.git',
   name: 'arillo:flow-router-helpers',
   summary: 'Template helpers for flow-router',
-  version: '0.4.2'
+  version: '0.4.3'
 });
 
 Package.onUse(function(api) {


### PR DESCRIPTION
Since we already have the `queryParam` helper, it only makes sense to also have the `param` helper, especially since Meteor 1.2 will bring in nested helpers so that having access to url parameters from within a helper would simplify route handling in templates.
