### PR TITLE
Add currentRoute helper

### DIFF
--- a/client/helpers.coffee
+++ b/client/helpers.coffee
@@ -29,8 +29,12 @@ param = (name) ->
 queryParam = (key) ->
   FlowRouter.getQueryParam(key);
 
+# get current route name
+currentRoute = () ->
+  FlowRouter.getRouteName()
+
 # deprecated
-isSubReady = (sub) ->  
+isSubReady = (sub) ->
   return FlowRouter.subsReady(sub) if sub
   return FlowRouter.subsReady()
 
@@ -41,5 +45,6 @@ helpers =
   param: param
   queryParam: queryParam
   isSubReady: isSubReady
+  currentRoute: currentRoute
 
 Template.registerHelper name, func for own name, func of helpers


### PR DESCRIPTION
I find this useful when adding a CSS class dynamically based on the current template's name. Doing so allows me to nest CSS rules under the scope of individual templates.

i.e.

```
<div class={{currentRoute}}>
  ...
</div>
```

[FlowRouter. getRouteName()](https://github.com/kadirahq/flow-router#flowroutergetroutename) is a reactive data source, and so this helper is also reactive.

Will be happy to update the doc if this is mergeable.
